### PR TITLE
Footer cleanup + About/Resources/Contact pages + i18n

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -34,6 +34,15 @@ export default function App({ Component, pageProps, emotionCache = clientSideEmo
     const [queryClient] = useState(() => new QueryClient(defaultQueryOption))
 
     useEffect(() => {
+        // 🥚 Easter egg — for the curious who open the console.
+        console.log(
+            "%cTiketQ ✈️%c\nCrafted by Alvian — github.com/alvianzf",
+            "font-size:22px;font-weight:800;color:#FF5A00;",
+            "font-size:12px;color:#4267B2;"
+        );
+    }, []);
+
+    useEffect(() => {
         // Connect to the backend socket server using unified dynamic API URL resolution
         const apiUrl = getApiUrl();
 

--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -1,0 +1,78 @@
+import { NextPageWithLayout } from "@interfaces/common";
+import Head from "next/head";
+import { AppLayout } from "@layouts";
+import { Card, CardContent } from "@mui/material";
+import { useTranslation } from "react-i18next";
+import { Plane, Ship, Car, ShieldCheck, Sparkles, BadgeCheck } from "lucide-react";
+
+const AboutPage: NextPageWithLayout = () => {
+    const { t } = useTranslation();
+
+    const offerings = [
+        { icon: <Plane size={22} className="text-[#ff5a00]" />, title: t('pages.about.offer_flights'), body: t('pages.about.offer_flights_desc') },
+        { icon: <Ship size={22} className="text-[#ff5a00]" />, title: t('pages.about.offer_ferry'), body: t('pages.about.offer_ferry_desc') },
+        { icon: <Car size={22} className="text-[#ff5a00]" />, title: t('pages.about.offer_car'), body: t('pages.about.offer_car_desc') },
+    ];
+
+    const reasons = [
+        { icon: <BadgeCheck size={22} className="text-primary" />, title: t('pages.about.why_1_title'), body: t('pages.about.why_1_body') },
+        { icon: <Sparkles size={22} className="text-primary" />, title: t('pages.about.why_2_title'), body: t('pages.about.why_2_body') },
+        { icon: <ShieldCheck size={22} className="text-primary" />, title: t('pages.about.why_3_title'), body: t('pages.about.why_3_body') },
+    ];
+
+    return (
+        <div className="min-h-screen py-14 px-5">
+            <Head>
+                <title>{`${t('pages.about.title')} — TiketQ`}</title>
+            </Head>
+
+            <div className="max-w-[960px] mx-auto flex flex-col gap-12">
+                <header className="text-center space-y-3">
+                    <h1 className="text-4xl font-extrabold text-slate-800 tracking-tight">{t('pages.about.title')}</h1>
+                    <p className="text-slate-500 font-medium max-w-2xl mx-auto leading-relaxed">{t('pages.about.subtitle')}</p>
+                </header>
+
+                <Card className="rounded-3xl">
+                    <CardContent className="p-8 space-y-3">
+                        <h2 className="text-xl font-bold text-slate-800">{t('pages.about.mission_title')}</h2>
+                        <p className="text-slate-600 leading-relaxed">{t('pages.about.mission_body')}</p>
+                    </CardContent>
+                </Card>
+
+                <section className="space-y-5">
+                    <h2 className="text-xl font-bold text-slate-800">{t('pages.about.offer_title')}</h2>
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+                        {offerings.map((o) => (
+                            <Card key={o.title} className="rounded-2xl h-full">
+                                <CardContent className="p-6 space-y-2">
+                                    <div className="w-11 h-11 rounded-xl bg-orange-500/10 flex items-center justify-center">{o.icon}</div>
+                                    <h3 className="font-bold text-slate-800">{o.title}</h3>
+                                    <p className="text-slate-500 text-sm leading-relaxed">{o.body}</p>
+                                </CardContent>
+                            </Card>
+                        ))}
+                    </div>
+                </section>
+
+                <section className="space-y-5">
+                    <h2 className="text-xl font-bold text-slate-800">{t('pages.about.why_title')}</h2>
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+                        {reasons.map((r) => (
+                            <Card key={r.title} className="rounded-2xl h-full">
+                                <CardContent className="p-6 space-y-2">
+                                    <div className="w-11 h-11 rounded-xl bg-primary/10 flex items-center justify-center">{r.icon}</div>
+                                    <h3 className="font-bold text-slate-800">{r.title}</h3>
+                                    <p className="text-slate-500 text-sm leading-relaxed">{r.body}</p>
+                                </CardContent>
+                            </Card>
+                        ))}
+                    </div>
+                </section>
+            </div>
+        </div>
+    );
+};
+
+AboutPage.getLayout = (page) => <AppLayout>{page}</AppLayout>;
+
+export default AboutPage;

--- a/pages/contact/index.tsx
+++ b/pages/contact/index.tsx
@@ -1,0 +1,74 @@
+import { NextPageWithLayout } from "@interfaces/common";
+import Head from "next/head";
+import { AppLayout } from "@layouts";
+import { Card, CardContent } from "@mui/material";
+import { useTranslation } from "react-i18next";
+import { Mail, MessageCircle, Phone, Clock, MapPin } from "lucide-react";
+
+const ContactPage: NextPageWithLayout = () => {
+    const { t } = useTranslation();
+
+    const channels = [
+        { icon: <Mail size={20} className="text-[#ff5a00]" />, label: t('pages.contact.email_label'), value: t('pages.contact.email_value'), href: `mailto:${t('pages.contact.email_value')}` },
+        { icon: <MessageCircle size={20} className="text-[#ff5a00]" />, label: t('pages.contact.whatsapp_label'), value: t('pages.contact.whatsapp_value'), href: `https://wa.me/${t('pages.contact.whatsapp_value').replace(/[^0-9]/g, '')}` },
+        { icon: <Phone size={20} className="text-[#ff5a00]" />, label: t('pages.contact.phone_label'), value: t('pages.contact.phone_value'), href: `tel:${t('pages.contact.phone_value').replace(/\s/g, '')}` },
+    ];
+
+    const details = [
+        { icon: <Clock size={20} className="text-primary" />, label: t('pages.contact.hours_label'), value: t('pages.contact.hours_value') },
+        { icon: <MapPin size={20} className="text-primary" />, label: t('pages.contact.address_label'), value: t('pages.contact.address_value') },
+    ];
+
+    return (
+        <div className="min-h-screen py-14 px-5">
+            <Head>
+                <title>{`${t('pages.contact.title')} — TiketQ`}</title>
+            </Head>
+
+            <div className="max-w-[860px] mx-auto flex flex-col gap-10">
+                <header className="text-center space-y-3">
+                    <h1 className="text-4xl font-extrabold text-slate-800 tracking-tight">{t('pages.contact.title')}</h1>
+                    <p className="text-slate-500 font-medium max-w-2xl mx-auto leading-relaxed">{t('pages.contact.subtitle')}</p>
+                </header>
+
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+                    {channels.map((c) => (
+                        <a key={c.label} href={c.href} target="_blank" rel="noopener noreferrer" className="block">
+                            <Card className="rounded-2xl h-full hover:shadow-lg transition-shadow">
+                                <CardContent className="p-6 space-y-2">
+                                    <div className="w-11 h-11 rounded-xl bg-orange-500/10 flex items-center justify-center">{c.icon}</div>
+                                    <p className="font-bold text-slate-800 text-sm">{c.label}</p>
+                                    <p className="text-slate-600 text-sm break-words">{c.value}</p>
+                                </CardContent>
+                            </Card>
+                        </a>
+                    ))}
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+                    {details.map((d) => (
+                        <Card key={d.label} className="rounded-2xl">
+                            <CardContent className="p-6 flex items-center gap-4">
+                                <div className="w-11 h-11 rounded-xl bg-primary/10 flex items-center justify-center shrink-0">{d.icon}</div>
+                                <div>
+                                    <p className="font-bold text-slate-800 text-sm">{d.label}</p>
+                                    <p className="text-slate-600 text-sm">{d.value}</p>
+                                </div>
+                            </CardContent>
+                        </Card>
+                    ))}
+                </div>
+
+                <Card className="rounded-2xl bg-orange-500/5 border border-orange-500/20">
+                    <CardContent className="p-6">
+                        <p className="text-slate-600 text-sm leading-relaxed">{t('pages.contact.cs_note')}</p>
+                    </CardContent>
+                </Card>
+            </div>
+        </div>
+    );
+};
+
+ContactPage.getLayout = (page) => <AppLayout>{page}</AppLayout>;
+
+export default ContactPage;

--- a/pages/resources/index.tsx
+++ b/pages/resources/index.tsx
@@ -1,0 +1,50 @@
+import { NextPageWithLayout } from "@interfaces/common";
+import Head from "next/head";
+import { AppLayout } from "@layouts";
+import { Card, CardContent } from "@mui/material";
+import { useTranslation } from "react-i18next";
+import { Lock, FileText, RotateCcw, HelpCircle } from "lucide-react";
+
+const ResourcesPage: NextPageWithLayout = () => {
+    const { t } = useTranslation();
+
+    const sections = [
+        { icon: <Lock size={20} className="text-primary" />, title: t('pages.resources.privacy_title'), body: t('pages.resources.privacy_body') },
+        { icon: <FileText size={20} className="text-primary" />, title: t('pages.resources.terms_title'), body: t('pages.resources.terms_body') },
+        { icon: <RotateCcw size={20} className="text-primary" />, title: t('pages.resources.refund_title'), body: t('pages.resources.refund_body') },
+        { icon: <HelpCircle size={20} className="text-primary" />, title: t('pages.resources.faq_title'), body: t('pages.resources.faq_body') },
+    ];
+
+    return (
+        <div className="min-h-screen py-14 px-5">
+            <Head>
+                <title>{`${t('pages.resources.title')} — TiketQ`}</title>
+            </Head>
+
+            <div className="max-w-[860px] mx-auto flex flex-col gap-10">
+                <header className="text-center space-y-3">
+                    <h1 className="text-4xl font-extrabold text-slate-800 tracking-tight">{t('pages.resources.title')}</h1>
+                    <p className="text-slate-500 font-medium max-w-2xl mx-auto leading-relaxed">{t('pages.resources.subtitle')}</p>
+                </header>
+
+                <div className="flex flex-col gap-5">
+                    {sections.map((s) => (
+                        <Card key={s.title} className="rounded-2xl">
+                            <CardContent className="p-6 space-y-2">
+                                <div className="flex items-center gap-3">
+                                    <div className="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center">{s.icon}</div>
+                                    <h2 className="text-lg font-bold text-slate-800">{s.title}</h2>
+                                </div>
+                                <p className="text-slate-600 text-sm leading-relaxed">{s.body}</p>
+                            </CardContent>
+                        </Card>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+ResourcesPage.getLayout = (page) => <AppLayout>{page}</AppLayout>;
+
+export default ResourcesPage;

--- a/specs/03-DESIGN-SYSTEM-AND-UI.md
+++ b/specs/03-DESIGN-SYSTEM-AND-UI.md
@@ -116,6 +116,32 @@ Reference implementation: `src/components/AppNavbar/index.tsx` uses `<Button com
 
 > Distinction: *navigation* must be link-based. *Post-action, programmatic* navigation after an async result is still done imperatively with `router.push()` inside a handler — e.g. `Checkout` pushes to `/checkout/payment` in the `bookFlight` mutation's `onSuccess`, and `DanaPayment` navigates on a `booking:update` push. The rule targets user-initiated link clicks, not side-effect redirects.
 
+## 5b. Forms & Submission (convention)
+
+**Every form must submit on Enter.** Wrap the fields in a native `<form onSubmit={...}>` and give the primary action `type="submit"`:
+
+```tsx
+// ✅ Correct — Enter in any field submits; the button is the submit control
+<form onSubmit={handleSubmit(onValid)}>
+  <TextField ... />
+  <Button type="submit">Continue</Button>
+</form>
+
+// ❌ Wrong — no <form>, submission only via onClick; Enter does nothing
+<TextField ... />
+<Button onClick={onValid}>Continue</Button>
+```
+
+- With `react-hook-form`, the submit control is `<Button type="submit">` and the wrapper is `<form onSubmit={handleSubmit(onValid)}>`.
+- Reference implementation: `pages/history` wraps its lookup in `<form onSubmit={handleSearch}>` with a `type="submit"` button, so Enter submits.
+- A dual-purpose "email or phone" field (e.g. `LoginForm`) stays `type="text"` (so a phone number isn't rejected by email validation), but the surrounding form must still submit on Enter.
+
+## 5c. Footer & Static Content Pages
+
+The site `Footer` (`src/components/Footer`) has four columns — brand, **Navigation** (site map: Flights `/`, Ferry `/ferry`, Car Rental `/car-rental`, My Bookings `/history`), **About Us**, and **Contact Us** — plus a bottom bar with copyright, company name, and social icons. All links use `next/link` (`component={Link}` / `<Link>`), per the navigation rule. There is no "Get the App" section and no in-footer AI promo banner.
+
+The About/Contact/Resources links resolve to real static pages: `pages/about` (`pages.about.*`), `pages/resources` (`pages.resources.*`, i.e. Privacy / Terms / Refund / FAQ), and `pages/contact` (`pages.contact.*`, contact channels). Each is a `NextPageWithLayout` under `AppLayout` and is fully bilingual via the `pages` locale group (`src/locales/pages/{id,en}.json`). See `07-NON-FUNCTIONAL.md` for i18n.
+
 ## 6. Responsive Approach
 
 Full detail in `07-NON-FUNCTIONAL.md`; the design-system essentials (from `docs/RESPONSIVE.md`):

--- a/specs/04-USER-FLOWS.md
+++ b/specs/04-USER-FLOWS.md
@@ -22,6 +22,15 @@
 
 The form uses `react-hook-form` with a `yup` resolver (`src/components/Checkout/forms/useForm.ts` for checkout; `SearchFlight/forms/useForm.ts` for search). Trip type is a `watch`ed field driving conditional return-date and multi-city UI. Submit builds a `Record<string,string>` query and `router.push({ pathname: '/flights', query })`.
 
+### Planned enhancement — International search toggle
+
+**Status: planned, not yet implemented.** Today the airport/destination set is scoped to Indonesian domestic hubs to keep the dataset small (the backend `routes/api/flight/airports` route prioritizes ~10 ID hubs; the flight provider supports international but it was filtered out for size). This enhancement adds opt-in international search:
+
+- **Toggle control** — a **"International"** toggle on the flight `SearchFlight` form. Default **off** = domestic (Indonesia) only, preserving today's behavior. When **on**, the search includes international destinations and flights as well (the provider already supports this), so results are **ALL** = domestic + international.
+- **Airport dropdown grouping** — when the toggle is active, the origin/destination airport dropdown is split into two labelled sections with a visual separator: **Domestic** and **International**. The sections stack **vertically** (Domestic group first, then a separator, then International). When the toggle is off, only the Domestic group is shown (current behavior).
+- **Data source** — flight results already carry an `isInternational` flag (`src/api/searchFlights/types.ts`), which can drive result labelling; airports need a domestic/international classification (from the provider or a maintained list) to populate the two dropdown groups.
+- **Backend** — the airports route (and the flight-search provider request) must stop scoping to domestic when the toggle is on; expect a larger airport payload, so keep the Redis cache and consider paginating/typeahead (`/api/flight/search-airport/:q`) for the international set.
+
 ### Checkout data collection & booking
 
 `Checkout` (`src/components/Checkout/index.tsx`) is a `FormProvider`-wrapped multi-tab form:

--- a/specs/06-AI-CHATBOT.md
+++ b/specs/06-AI-CHATBOT.md
@@ -105,3 +105,18 @@ sequenceDiagram
 ## 5. Localization
 
 Promo/marketing copy for the widget is localized in `src/locales/common/{en,id}.json` (`common.ai_promo_title`, `common.ai_promo_banner_title/desc/example_flight/example_ferry`, `common.ai_bubble`). See `07-NON-FUNCTIONAL.md` for the i18n system.
+
+## 6. Planned enhancements
+
+**Status: planned, not yet implemented.**
+
+### 6.1 Round-trip & multi-city in chat
+The chat should support the same trip types as the web `SearchFlight` form:
+- **Round-trip** — `search_flights` already accepts `returnDate` (backend `services/chatService.js`), but the chat flow does not yet present outbound + return selection as a pair. The assistant should search both legs, render outbound and return options (as cards, see §6.2), and carry both selected `searchId`s into `execute_flight_booking`.
+- **Multi-city** — not yet supported by any tool. Requires a new tool (or an extended `search_flights`) that accepts an ordered list of segments (each `{ departure, arrival, departureDate }`), returns per-segment options, and lets the user pick one flight per segment before booking. Mirror the web multi-city flow (`SearchFlight` multi-city UI, `02-STATE-AND-DATA.md`).
+
+### 6.2 Card-first responses
+Bias the assistant toward **rich cards over plain text** for anything structured — search results, a selected itinerary summary, booking confirmations, payment instructions, and booking-history results — to keep the conversation visual and engaging. Concretely:
+- Add a `booking_history` `chat:tool_result` card so `get_booking_history` renders a scannable list of bookings (today it returns text only — see the backend `05-INTEGRATIONS.md`/`AI_ARCHITECTURE.md`).
+- Add a round-trip/multi-city itinerary card that shows all chosen legs together before payment.
+- Keep the existing `flight_results` / `ferry_results` / `dana_payment` / `booking_summary` / `customer_service_card` types; text from the model stays as a short narration around the card, per the system prompt's "don't list options in text" rule.

--- a/specs/07-NON-FUNCTIONAL.md
+++ b/specs/07-NON-FUNCTIONAL.md
@@ -19,7 +19,7 @@
 `src/utils/i18n/translations.ts` `require`s per-domain JSON files and merges them into a flat `en`/`id` resource bundle. The domain groups are:
 
 ```
-meta, home, footer, tickets, checkout, profile, form, common
+meta, home, footer, tickets, checkout, profile, form, common, pages
 ```
 
 Each lives under `src/locales/<group>/{en.json,id.json}` (the JSON is wrapped in a top-level `en`/`id` key that the loader unwraps). To add copy, add the key to **both** `en.json` and `id.json` of the relevant group.

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,10 +1,20 @@
 import Facebook from "@icons/Facebook";
 import Instagram from "@icons/Instagram";
 import Twitter from "@icons/Twitter";
+import Link from "next/link";
 import { useTranslation } from "react-i18next"
 
 const Footer = () => {
     const { t } = useTranslation();
+
+    const navLinks = [
+        { label: t('footer.nav_flights'), href: '/' },
+        { label: t('footer.nav_ferry'), href: '/ferry' },
+        { label: t('footer.nav_car'), href: '/car-rental' },
+        { label: t('footer.nav_history'), href: '/history' },
+    ];
+
+    const linkClass = "text-slate-600 hover:text-primary text-sm transition-colors";
 
     return (
         <div className="flex justify-center mt-20 mb-10 mx-[40px] lg:mx-0">
@@ -15,54 +25,41 @@ const Footer = () => {
                         <p className="text-slate-500 text-sm leading-relaxed max-w-xs">{t('footer.description') || "Premium travel booking experience with the best prices and services."}</p>
                     </div>
                     <div className="flex flex-col gap-3">
-                        <p className="font-bold text-dark uppercase tracking-wider text-xs">{t('footer.contact_us')}</p>
-                        <a href="#" className="text-slate-600 hover:text-primary text-sm transition-colors">{t('footer.customer_service')}</a>
-                        <a href="#" className="text-slate-600 hover:text-primary text-sm transition-colors">{t('footer.service_protection')}</a>
-                        <a href="#" className="text-slate-600 hover:text-primary text-sm transition-colors">{t('footer.feedback')}</a>
+                        <p className="font-bold text-dark uppercase tracking-wider text-xs">{t('footer.nav_title')}</p>
+                        {navLinks.map((item) => (
+                            <Link key={item.href} href={item.href} className={linkClass}>{item.label}</Link>
+                        ))}
                     </div>
                     <div className="flex flex-col gap-3">
                         <p className="font-bold text-dark uppercase tracking-wider text-xs">{t('footer.about_us_title')}</p>
-                        <a href="#" className="text-slate-600 hover:text-primary text-sm transition-colors">{t('footer.about_us')}</a>
-                        <a href="#" className="text-slate-600 hover:text-primary text-sm transition-colors">{t('footer.news')}</a>
-                        <a href="#" className="text-slate-600 hover:text-primary text-sm transition-colors">{t('footer.resouces_and_policies')}</a>
+                        <Link href="/about" className={linkClass}>{t('footer.about_us')}</Link>
+                        <Link href="/resources" className={linkClass}>{t('footer.resouces_and_policies')}</Link>
                     </div>
-                    <div className="flex flex-col gap-4">
-                        <p className="font-bold text-dark uppercase tracking-wider text-xs">{t('footer.get_the_app')}</p>
-                        <div className="flex flex-col gap-2">
-                             <a href="#" className="text-slate-600 hover:text-primary text-sm transition-colors">{t('footer.android_app')}</a>
-                             <a href="#" className="text-slate-600 hover:text-primary text-sm transition-colors">{t('footer.iphone_app')}</a>
-                        </div>
-                        <div className="flex flex-row gap-4 mt-2">
-                            <div className="text-slate-400 hover:text-primary transition-colors cursor-pointer">
-                                <Facebook width={24} height={24} />
-                            </div>
-                            <div className="text-slate-400 hover:text-primary transition-colors cursor-pointer">
-                                <Twitter width={24} height={24} />
-                            </div>
-                            <div className="text-slate-400 hover:text-primary transition-colors cursor-pointer">
-                                <Instagram width={24} height={24} />
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                
-                {/* AI Banner in Footer */}
-                <div className="my-10 p-6 rounded-2xl bg-gradient-to-r from-orange-500/10 to-primary/10 border border-orange-500/20 flex flex-col md:flex-row items-center justify-between gap-6">
-                    <div className="flex flex-col md:flex-row items-center gap-4 text-center md:text-left w-full">
-                        <div className="w-12 h-12 rounded-full bg-gradient-to-tr from-primary to-orange-500 flex items-center justify-center shadow-lg shadow-orange-500/30 text-white shrink-0">
-                             <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"></path></svg>
-                        </div>
-                        <div className="flex-1">
-                            <p className="text-dark font-bold text-lg">{t('common.ai_promo_title')}</p>
-                            <p className="text-slate-500 text-sm mt-1">{t('common.ai_promo_desc_footer')}</p>
-                        </div>
+                    <div className="flex flex-col gap-3">
+                        <p className="font-bold text-dark uppercase tracking-wider text-xs">{t('footer.contact_us')}</p>
+                        <Link href="/contact" className={linkClass}>{t('footer.customer_service')}</Link>
+                        <Link href="/contact" className={linkClass}>{t('footer.service_protection')}</Link>
+                        <Link href="/contact" className={linkClass}>{t('footer.feedback')}</Link>
                     </div>
                 </div>
 
                 <hr className="border-slate-200" />
                 <div className="flex flex-col md:flex-row justify-between items-center gap-4 text-slate-400 text-xs font-medium">
                     <p>{t('footer.copyright')}</p>
-                    <p>{t('footer.company_name')}</p>
+                    <div className="flex items-center gap-6">
+                        <div className="flex flex-row gap-4">
+                            <a href="#" aria-label="Facebook" className="text-slate-400 hover:text-primary transition-colors">
+                                <Facebook width={20} height={20} />
+                            </a>
+                            <a href="#" aria-label="Twitter" className="text-slate-400 hover:text-primary transition-colors">
+                                <Twitter width={20} height={20} />
+                            </a>
+                            <a href="#" aria-label="Instagram" className="text-slate-400 hover:text-primary transition-colors">
+                                <Instagram width={20} height={20} />
+                            </a>
+                        </div>
+                        <p>{t('footer.company_name')}</p>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/locales/footer/en.json
+++ b/src/locales/footer/en.json
@@ -1,7 +1,7 @@
 {
     "en": {
         "footer": {
-            "description": "Your trusted travel partner for booking flights and ferries across Southeast Asia and beyond.",
+            "description": "Your trusted travel partner for booking flights and ferries in Batam and across Indonesia.",
             "nav_title": "Navigation",
             "nav_flights": "Flights",
             "nav_ferry": "Ferry",

--- a/src/locales/footer/en.json
+++ b/src/locales/footer/en.json
@@ -2,17 +2,18 @@
     "en": {
         "footer": {
             "description": "Your trusted travel partner for booking flights and ferries across Southeast Asia and beyond.",
+            "nav_title": "Navigation",
+            "nav_flights": "Flights",
+            "nav_ferry": "Ferry",
+            "nav_car": "Car Rental",
+            "nav_history": "My Bookings",
             "contact_us": "Contact Us",
             "customer_service": "Customer Service",
             "service_protection": "Service Protection",
             "feedback": "Feedback",
             "about_us_title": "About Us",
             "about_us": "About TiketQ",
-            "news": "News",
             "resouces_and_policies": "Resources and Policies",
-            "get_the_app": "Get The App",
-            "android_app": "Android App",
-            "iphone_app": "Iphone App",
             "copyright": "Copyright © 2026 tiketq.com Travel Pte Ltd All rights reserved",
             "company_name": "PT INI TIKET QUE | Indonesia"
         }

--- a/src/locales/footer/id.json
+++ b/src/locales/footer/id.json
@@ -1,7 +1,7 @@
 {
     "id": {
         "footer": {
-            "description": "Mitra perjalanan terpercaya Anda untuk pemesanan tiket pesawat dan kapal feri di seluruh Asia Tenggara dan sekitarnya.",
+            "description": "Mitra perjalanan terpercaya Anda untuk pemesanan tiket pesawat dan kapal feri di Batam dan berbagai wilayah Indonesia lainnya.",
             "nav_title": "Navigasi",
             "nav_flights": "Pesawat",
             "nav_ferry": "Feri",

--- a/src/locales/footer/id.json
+++ b/src/locales/footer/id.json
@@ -2,17 +2,18 @@
     "id": {
         "footer": {
             "description": "Mitra perjalanan terpercaya Anda untuk pemesanan tiket pesawat dan kapal feri di seluruh Asia Tenggara dan sekitarnya.",
+            "nav_title": "Navigasi",
+            "nav_flights": "Pesawat",
+            "nav_ferry": "Feri",
+            "nav_car": "Sewa Mobil",
+            "nav_history": "Riwayat Pesanan",
             "contact_us": "Hubungi Kami",
             "customer_service": "Layanan Pelanggan",
             "service_protection": "Perlindungan Layanan",
             "feedback": "Feedback",
             "about_us_title": "Tentang Kami",
             "about_us": "Tentang TiketQ",
-            "news": "Berita",
             "resouces_and_policies": "Sumber Daya dan Kebijakan",
-            "get_the_app": "Dapatkan Aplikasi",
-            "android_app": "Android App",
-            "iphone_app": "Iphone App",
             "copyright": "Hak Cipta © 2026 tiketq.com Travel Pte Ltd Semua hak dilindungi undang-undang",
             "company_name": "PT INI TIKET QUE | Indonesia"
         }

--- a/src/locales/pages/en.json
+++ b/src/locales/pages/en.json
@@ -1,0 +1,53 @@
+{
+    "en": {
+        "pages": {
+            "about": {
+                "title": "About TiketQ",
+                "subtitle": "Your trusted travel partner for booking flights, ferries, and car rentals across Southeast Asia.",
+                "mission_title": "Our Mission",
+                "mission_body": "We believe booking travel should be as easy as chatting with a friend. TiketQ brings flights, ferries, and car rentals together on one fast, transparent, and reliable platform — no hidden fees, no hassle.",
+                "offer_title": "What We Offer",
+                "offer_flights": "Flights",
+                "offer_flights_desc": "Search and book domestic and international flights at the best prices, with instant e-tickets.",
+                "offer_ferry": "Ferry Tickets",
+                "offer_ferry_desc": "Batam–Singapore and regional ferry routes, with live schedules and availability.",
+                "offer_car": "Car Rental",
+                "offer_car_desc": "Rent a vehicle for your trip with flexible options and a simple process.",
+                "why_title": "Why Choose TiketQ",
+                "why_1_title": "Transparent Pricing",
+                "why_1_body": "The price you see is the price you pay — no hidden charges.",
+                "why_2_title": "24/7 AI Assistant",
+                "why_2_body": "Book and manage your trips just by chatting with the TiketQ assistant.",
+                "why_3_title": "Secure Payments",
+                "why_3_body": "Payments are processed securely through DANA and trusted bank virtual accounts."
+            },
+            "resources": {
+                "title": "Resources and Policies",
+                "subtitle": "Important information about how we protect you and govern our services.",
+                "privacy_title": "Privacy Policy",
+                "privacy_body": "We collect personal data (name, email, phone number, and passenger details) only to process your bookings and issue tickets. Your data is never sold to third parties and is shared with airline partners, ferry operators, or payment providers solely as needed to complete your transaction.",
+                "terms_title": "Terms of Service",
+                "terms_body": "By using TiketQ you agree to provide accurate information, comply with the terms of the relevant airlines and ferry operators, and use the platform only for legitimate bookings. Prices and availability may change until a booking is confirmed.",
+                "refund_title": "Refund & Cancellation Policy",
+                "refund_body": "Refunds and cancellations follow the terms of the relevant airline or ferry operator. To request a cancellation or refund, please contact our team via the Contact Us page and include your booking code.",
+                "faq_title": "Frequently Asked Questions",
+                "faq_body": "Need quick help? The TiketQ AI assistant is available 24/7 in the bottom-right corner of your screen to help with searches, bookings, and questions about your orders."
+            },
+            "contact": {
+                "title": "Contact Us",
+                "subtitle": "Our team is here to help. Reach us through any of the channels below.",
+                "email_label": "Email",
+                "email_value": "support@tiketq.com",
+                "whatsapp_label": "WhatsApp",
+                "whatsapp_value": "+62 811-1000-2000",
+                "phone_label": "Phone",
+                "phone_value": "+62 21 5000 1000",
+                "hours_label": "Operating Hours",
+                "hours_value": "Monday–Sunday, 08:00–22:00 (WIB)",
+                "address_label": "Address",
+                "address_value": "PT Ini Tiket Que, Jakarta, Indonesia",
+                "cs_note": "For order-related questions, include your booking code so we can help you faster. You can also use the TiketQ AI assistant any time."
+            }
+        }
+    }
+}

--- a/src/locales/pages/en.json
+++ b/src/locales/pages/en.json
@@ -3,7 +3,7 @@
         "pages": {
             "about": {
                 "title": "About TiketQ",
-                "subtitle": "Your trusted travel partner for booking flights, ferries, and car rentals across Southeast Asia.",
+                "subtitle": "Your trusted travel partner for booking flights, ferries, and car rentals in Batam and across Indonesia.",
                 "mission_title": "Our Mission",
                 "mission_body": "We believe booking travel should be as easy as chatting with a friend. TiketQ brings flights, ferries, and car rentals together on one fast, transparent, and reliable platform — no hidden fees, no hassle.",
                 "offer_title": "What We Offer",

--- a/src/locales/pages/id.json
+++ b/src/locales/pages/id.json
@@ -3,7 +3,7 @@
         "pages": {
             "about": {
                 "title": "Tentang TiketQ",
-                "subtitle": "Mitra perjalanan tepercaya Anda untuk pemesanan tiket pesawat, kapal feri, dan sewa mobil di seluruh Asia Tenggara.",
+                "subtitle": "Mitra perjalanan tepercaya Anda untuk pemesanan tiket pesawat, kapal feri, dan sewa mobil di Batam dan berbagai wilayah Indonesia lainnya.",
                 "mission_title": "Misi Kami",
                 "mission_body": "Kami percaya memesan perjalanan seharusnya semudah mengobrol dengan teman. TiketQ menyatukan tiket pesawat, kapal feri, dan sewa mobil dalam satu platform yang cepat, transparan, dan dapat diandalkan — tanpa biaya tersembunyi dan tanpa kerumitan.",
                 "offer_title": "Apa yang Kami Tawarkan",

--- a/src/locales/pages/id.json
+++ b/src/locales/pages/id.json
@@ -1,0 +1,53 @@
+{
+    "id": {
+        "pages": {
+            "about": {
+                "title": "Tentang TiketQ",
+                "subtitle": "Mitra perjalanan tepercaya Anda untuk pemesanan tiket pesawat, kapal feri, dan sewa mobil di seluruh Asia Tenggara.",
+                "mission_title": "Misi Kami",
+                "mission_body": "Kami percaya memesan perjalanan seharusnya semudah mengobrol dengan teman. TiketQ menyatukan tiket pesawat, kapal feri, dan sewa mobil dalam satu platform yang cepat, transparan, dan dapat diandalkan — tanpa biaya tersembunyi dan tanpa kerumitan.",
+                "offer_title": "Apa yang Kami Tawarkan",
+                "offer_flights": "Tiket Pesawat",
+                "offer_flights_desc": "Cari dan pesan penerbangan domestik maupun internasional dengan harga terbaik dan e-tiket instan.",
+                "offer_ferry": "Tiket Kapal Feri",
+                "offer_ferry_desc": "Rute feri Batam–Singapura dan sekitarnya, lengkap dengan jadwal dan ketersediaan langsung.",
+                "offer_car": "Sewa Mobil",
+                "offer_car_desc": "Sewa kendaraan untuk perjalanan Anda dengan pilihan yang fleksibel dan proses yang mudah.",
+                "why_title": "Mengapa Memilih TiketQ",
+                "why_1_title": "Harga Transparan",
+                "why_1_body": "Harga yang Anda lihat adalah harga yang Anda bayar — tanpa biaya tersembunyi.",
+                "why_2_title": "Asisten AI 24/7",
+                "why_2_body": "Pesan dan kelola perjalanan Anda cukup dengan mengobrol bersama asisten TiketQ.",
+                "why_3_title": "Pembayaran Aman",
+                "why_3_body": "Pembayaran diproses dengan aman melalui DANA dan bank virtual account tepercaya."
+            },
+            "resources": {
+                "title": "Sumber Daya dan Kebijakan",
+                "subtitle": "Informasi penting tentang cara kami melindungi Anda dan mengatur layanan kami.",
+                "privacy_title": "Kebijakan Privasi",
+                "privacy_body": "Kami mengumpulkan data pribadi (nama, email, nomor telepon, dan detail penumpang) hanya untuk memproses pemesanan Anda dan menerbitkan tiket. Data Anda tidak dijual kepada pihak ketiga dan hanya dibagikan kepada mitra maskapai, operator feri, atau penyedia pembayaran sejauh diperlukan untuk menyelesaikan transaksi Anda.",
+                "terms_title": "Syarat dan Ketentuan",
+                "terms_body": "Dengan menggunakan TiketQ, Anda setuju untuk memberikan informasi yang akurat, mematuhi ketentuan maskapai dan operator feri terkait, serta menggunakan platform hanya untuk pemesanan yang sah. Harga dan ketersediaan dapat berubah hingga pemesanan dikonfirmasi.",
+                "refund_title": "Kebijakan Pengembalian Dana & Pembatalan",
+                "refund_body": "Pengembalian dana dan pembatalan mengikuti ketentuan maskapai atau operator feri terkait. Untuk permintaan pembatalan atau pengembalian dana, silakan hubungi tim kami melalui halaman Hubungi Kami dengan menyertakan kode pemesanan Anda.",
+                "faq_title": "Pertanyaan Umum",
+                "faq_body": "Butuh bantuan cepat? Asisten AI TiketQ tersedia 24/7 di pojok kanan bawah layar untuk membantu pencarian, pemesanan, dan pertanyaan seputar pesanan Anda."
+            },
+            "contact": {
+                "title": "Hubungi Kami",
+                "subtitle": "Tim kami siap membantu Anda. Hubungi kami melalui salah satu kanal di bawah ini.",
+                "email_label": "Email",
+                "email_value": "support@tiketq.com",
+                "whatsapp_label": "WhatsApp",
+                "whatsapp_value": "+62 811-1000-2000",
+                "phone_label": "Telepon",
+                "phone_value": "+62 21 5000 1000",
+                "hours_label": "Jam Operasional",
+                "hours_value": "Senin–Minggu, 08.00–22.00 WIB",
+                "address_label": "Alamat",
+                "address_value": "PT Ini Tiket Que, Jakarta, Indonesia",
+                "cs_note": "Untuk pertanyaan seputar pesanan, sertakan kode pemesanan Anda agar kami dapat membantu lebih cepat. Anda juga dapat menggunakan Asisten AI TiketQ kapan saja."
+            }
+        }
+    }
+}

--- a/src/utils/i18n/translations.ts
+++ b/src/utils/i18n/translations.ts
@@ -9,7 +9,8 @@ const localeGroups = [
     'checkout',
     'profile',
     'form',
-    'common'
+    'common',
+    'pages'
 ];
 
 const localeEnGroups = {};


### PR DESCRIPTION
## Summary
Home/footer changes plus three new drafted static pages, fully bilingual (id/en).

**Footer (`src/components/Footer`)**
- Removed the **"Dapatkan Aplikasi" (Get the App)** section and the in-footer **AI promo banner**.
- Removed the **"Berita" (News)** link.
- Added a **Navigation / site-map** column: Flights, Ferry, Car Rental, My Bookings.
- Wired About / Contact / Resources links to real pages via `next/link`; moved social icons to the bottom bar.

**New pages** (`NextPageWithLayout` + `AppLayout`, bilingual)
- `pages/about` — **Tentang TiketQ** (mission, offerings, why-us).
- `pages/resources` — **Sumber Daya dan Kebijakan** (Privacy / Terms / Refund / FAQ).
- `pages/contact` — **Hubungi Kami** (email / WhatsApp / phone / hours / address).

**i18n** — new `pages` locale group registered in `translations.ts`; footer nav keys added.

**Specs** — documented the footer + static pages and the **"forms submit on Enter"** convention (`03-DESIGN-SYSTEM-AND-UI`, `07-NON-FUNCTIONAL`).

## ⚠️ Placeholder contact details
The contact page uses **draft** contact values (`support@tiketq.com`, `+62 811-1000-2000`, `+62 21 5000 1000`, Jakarta address) — replace with the real ones in `src/locales/pages/{id,en}.json` before relying on them.

## Testing
- `npx tsc --noEmit` → no errors; all locale JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)