### PR TITLE
Multi-city flight search: date-ordering validation

### DIFF
--- a/specs/04-USER-FLOWS.md
+++ b/specs/04-USER-FLOWS.md
@@ -22,6 +22,8 @@
 
 The form uses `react-hook-form` with a `yup` resolver (`src/components/Checkout/forms/useForm.ts` for checkout; `SearchFlight/forms/useForm.ts` for search). Trip type is a `watch`ed field driving conditional return-date and multi-city UI. Submit builds a `Record<string,string>` query and `router.push({ pathname: '/flights', query })`.
 
+**Multi-city validation** (segments held in local `useState`, not `react-hook-form`): on submit, `handleMultiCitySearch` blocks the search and shows a `toast.error` if (1) any segment is missing its from/to/date, or (2) the segment dates are not non-decreasing in order — **each segment's departure date must be on or after the previous segment's date** (you can't have city 2 depart before city 1). Dates are `YYYY-MM-DD` strings compared lexicographically. Each segment's `DatePicker` also sets its `minDate` to the previous segment's date to prevent the out-of-order selection up front. (Previously the incomplete/out-of-order cases failed silently with a bare `return`.)
+
 ### Checkout data collection & booking
 
 `Checkout` (`src/components/Checkout/index.tsx`) is a `FormProvider`-wrapped multi-tab form:

--- a/src/components/SearchFlight/MultiCitySegment.tsx
+++ b/src/components/SearchFlight/MultiCitySegment.tsx
@@ -18,11 +18,12 @@ interface Props {
     airports: Airport[];
     isLoading: boolean;
     canRemove: boolean;
+    minDate?: string;
     onChange: (index: number, value: SegmentValue) => void;
     onRemove: (index: number) => void;
 }
 
-const MultiCitySegment = ({ index, value, airports, isLoading, canRemove, onChange, onRemove }: Props) => {
+const MultiCitySegment = ({ index, value, airports, isLoading, canRemove, minDate, onChange, onRemove }: Props) => {
     const { t } = useTranslation();
 
     return (
@@ -138,7 +139,7 @@ const MultiCitySegment = ({ index, value, airports, isLoading, canRemove, onChan
                 <p className="font-medium text-slate-800/80 text-sm">{t('tickets.departured_date')}</p>
                 <DatePicker
                     className="w-full"
-                    minDate={moment()}
+                    minDate={minDate ? moment(minDate) : moment()}
                     value={value.date ? moment(value.date) : null}
                     onChange={(v) => { if (v) onChange(index, { ...value, date: v.format('YYYY-MM-DD') }); }}
                     slotProps={{

--- a/src/components/SearchFlight/index.tsx
+++ b/src/components/SearchFlight/index.tsx
@@ -13,6 +13,7 @@ import useForm, { FormProps } from "./forms/useForm";
 import { useEffect, useState } from "react";
 import moment from "moment";
 import { useRouter } from "next/router";
+import { toast } from "react-toastify";
 
 const SearchFlight = () => {
     const [mounted, setMounted] = useState(false);
@@ -112,7 +113,15 @@ const SearchFlight = () => {
 
     const handleMultiCitySearch = () => {
         const valid = segments.every(s => s.from && s.to && s.date);
-        if (!valid) return;
+        if (!valid) {
+            toast.error(t('tickets.incomplete_segments'));
+            return;
+        }
+        const datesNonDecreasing = segments.every((s, i) => i === 0 || s.date >= segments[i - 1].date);
+        if (!datesNonDecreasing) {
+            toast.error(t('tickets.date_order_error'));
+            return;
+        }
         setIsSubmitting(true);
         push({
             pathname: '/flights',
@@ -177,6 +186,7 @@ const SearchFlight = () => {
                                 airports={items}
                                 isLoading={isAirportsLoading}
                                 canRemove={segments.length > 2}
+                                minDate={i > 0 ? segments[i - 1].date : undefined}
                                 onChange={(idx, val) => setSegments(prev => prev.map((s, j) => j === idx ? val : s))}
                                 onRemove={(idx) => setSegments(prev => prev.filter((_, j) => j !== idx))}
                             />

--- a/src/locales/tickets/en.json
+++ b/src/locales/tickets/en.json
@@ -61,7 +61,9 @@
             "select_outbound": "Select Outbound Flight",
             "select_return": "Select Return Flight",
             "no_trips_found": "No trips found for this date",
-            "error_loading_trips": "Failed to load trips"
+            "error_loading_trips": "Failed to load trips",
+            "incomplete_segments": "Please complete the departure, destination, and date for every flight.",
+            "date_order_error": "Each city's date must be on or after the previous city's date."
         }
     }
 }

--- a/src/locales/tickets/id.json
+++ b/src/locales/tickets/id.json
@@ -61,7 +61,9 @@
             "select_outbound": "Pilih Penerbangan Pergi",
             "select_return": "Pilih Penerbangan Pulang",
             "no_trips_found": "Tidak ada perjalanan untuk tanggal ini",
-            "error_loading_trips": "Gagal memuat perjalanan"
+            "error_loading_trips": "Gagal memuat perjalanan",
+            "incomplete_segments": "Harap lengkapi keberangkatan, tujuan, dan tanggal untuk setiap penerbangan.",
+            "date_order_error": "Tanggal setiap kota harus sama dengan atau setelah tanggal kota sebelumnya."
         }
     }
 }


### PR DESCRIPTION
## Summary
Adds the rule that a multi-city flight search's later segments can't depart **before** an earlier one.

- On submit, `handleMultiCitySearch` (`src/components/SearchFlight/index.tsx`) now blocks the search and shows a `toast.error` when (1) any segment is missing from/to/date, or (2) segment dates are not non-decreasing in order. Both cases previously failed **silently** (`if (!valid) return;`).
- Each segment's `DatePicker` (`MultiCitySegment.tsx`) sets `minDate` to the previous segment's date, so an out-of-order date can't be picked in the first place.
- Locale keys `tickets.incomplete_segments` / `tickets.date_order_error` added (en/id).
- Rule documented in `specs/04-USER-FLOWS.md`.

Dates are `YYYY-MM-DD` strings, compared lexicographically (correct chronological order).

## Testing
`npx tsc --noEmit` → no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)